### PR TITLE
Add configurable workflows with form-linked states

### DIFF
--- a/src/components/dashboard/WorkflowDefinitions.tsx
+++ b/src/components/dashboard/WorkflowDefinitions.tsx
@@ -9,11 +9,17 @@ export function WorkflowDefinitions() {
 
 	return (
 		<section className="mb-8">
-			<h2 className="text-xl font-semibold mb-4">
-				Recent Workflow Definitions
-			</h2>
+			<div className="mb-4 flex items-center justify-between">
+				<h2 className="text-xl font-semibold">Recent Workflow Definitions</h2>
+				<Link
+					to="/admin/workflow/new"
+					className="text-blue-500 hover:underline"
+				>
+					New Workflow
+				</Link>
+			</div>
 			{workflowDefinitionsQuery.data.map((wf) => (
-				<div key={wf.id} className="mb-4 p-4 border rounded">
+				<div key={wf.id} className="mb-4 rounded border p-4">
 					<div>
 						ID:{" "}
 						<Link
@@ -29,7 +35,7 @@ export function WorkflowDefinitions() {
 					<div>Version: {wf.version}</div>
 					<div>
 						Machine Config:{" "}
-						<pre className="text-sm bg-secondary text-secondary-foreground p-2 mt-2 rounded">
+						<pre className="mt-2 rounded bg-secondary p-2 text-sm text-secondary-foreground">
 							{JSON.stringify(wf.machineConfig, null, 2)}
 						</pre>
 					</div>

--- a/src/data/API/workflowDefinition.ts
+++ b/src/data/API/workflowDefinition.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
 import { createServerFn } from "@tanstack/react-start";
 import * as z from "zod";
+import { FormSchema as zodFormSchema } from "@/lib/form";
 import { DB } from "../DB";
 
 const workflowDefinitionQueryKeys = {
@@ -37,10 +38,38 @@ export const getWorkflowDefinitionbyIdQueryOptions = (id: number) =>
 		queryFn: () => getWorkflowDefinitionbyIdFn({ data: { id } }),
 	});
 
+const createWorkflowDefinitionServerFn = createServerFn({
+	method: "POST",
+})
+	.validator(
+		z.object({
+			name: z.string(),
+			machineConfig: z.record(z.any()),
+			forms: z
+				.record(
+					z.object({
+						formDefId: z.number().optional(),
+						schema: zodFormSchema.optional(),
+					}),
+				)
+				.optional(),
+		}),
+	)
+	.handler(async ({ data: { name, machineConfig, forms } }) =>
+		DB.workflowDefinition.mutations.createWorkflowDefinition(
+			name,
+			machineConfig,
+			forms,
+		),
+	);
+
 export const workflowDefinition = {
 	queries: {
 		getWorkflowDefinitionsQueryOptions,
 		getWorkflowDefinitionbyIdQueryOptions,
+	},
+	mutations: {
+		createWorkflowDefinitionServerFn,
 	},
 	queryKeys: workflowDefinitionQueryKeys,
 } as const;

--- a/src/data/DB/workflowDefinition.ts
+++ b/src/data/DB/workflowDefinition.ts
@@ -1,6 +1,8 @@
 import { desc, eq } from "drizzle-orm";
 import { dbClient } from "@/db/client";
-import { workflowDefinitions } from "@/db/schema";
+import { formDefinitions, workflowDefinitions } from "@/db/schema";
+import type { FormSchema } from "@/lib/form";
+import { getWorkflowStates } from "@/lib/workflow";
 
 /**
  * Retrieves up to five workflow definitions from the database, ordered by creation date in descending order.
@@ -35,9 +37,77 @@ const getWorkflowDefinition = async (id: number) => {
 	return workflows[0];
 };
 
+const createWorkflowDefinition = async (
+	name: string,
+	machineConfig: Record<string, any>,
+	forms?: Record<string, { formDefId?: number; schema?: FormSchema }>,
+) => {
+	const currentVersion = await dbClient
+		.select({ version: workflowDefinitions.version })
+		.from(workflowDefinitions)
+		.where(eq(workflowDefinitions.name, name))
+		.orderBy(desc(workflowDefinitions.version))
+		.limit(1);
+
+	const nextVersion = currentVersion.length ? currentVersion[0].version + 1 : 1;
+
+	const [newWorkflow] = await dbClient
+		.insert(workflowDefinitions)
+		.values({ name, version: nextVersion, machineConfig })
+		.returning();
+
+	const requiredStates = getWorkflowStates(machineConfig);
+
+	for (const state of requiredStates) {
+		const formInfo = forms?.[state];
+		let schema: FormSchema | undefined;
+
+		if (formInfo?.formDefId) {
+			const existing = await dbClient
+				.select({ schema: formDefinitions.schema })
+				.from(formDefinitions)
+				.where(eq(formDefinitions.id, formInfo.formDefId))
+				.limit(1);
+			if (existing.length) {
+				schema = existing[0].schema as FormSchema;
+			}
+		} else if (formInfo?.schema) {
+			schema = formInfo.schema;
+		}
+
+		if (!schema) {
+			schema = {
+				title: `${state} Form`,
+				description: "",
+				fields: [
+					{
+						name: "placeholder",
+						type: "text",
+						label: "Placeholder",
+						required: false,
+						description: "",
+					},
+				],
+			};
+		}
+
+		await dbClient.insert(formDefinitions).values({
+			workflowDefId: newWorkflow.id,
+			state,
+			version: 1,
+			schema,
+		});
+	}
+
+	return newWorkflow;
+};
+
 export const workflowDefinition = {
 	queries: {
 		getWorkflowDefinitions,
 		getWorkflowDefinition,
+	},
+	mutations: {
+		createWorkflowDefinition,
 	},
 };

--- a/src/lib/workflow.test.ts
+++ b/src/lib/workflow.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getWorkflowStates } from "./workflow";
+
+describe("getWorkflowStates", () => {
+	it("returns non-final states for linear workflow", () => {
+		const config = {
+			initial: "form1",
+			states: {
+				form1: { on: { NEXT: "form2" } },
+				form2: { type: "final" },
+			},
+		};
+		expect(getWorkflowStates(config)).toEqual(["form1"]);
+	});
+
+	it("handles parallel workflows", () => {
+		const config = {
+			initial: "draft",
+			states: {
+				draft: { on: { SUBMIT: "review" } },
+				review: {
+					type: "parallel",
+					states: {
+						market: {
+							initial: "pending",
+							states: {
+								pending: { on: { APPROVE: "approved" } },
+								approved: { type: "final" },
+								rejected: { type: "final" },
+							},
+						},
+						credit: {
+							initial: "pending",
+							states: {
+								pending: { on: { APPROVE: "approved" } },
+								approved: { type: "final" },
+								rejected: { type: "final" },
+							},
+						},
+					},
+				},
+				completed: { type: "final" },
+			},
+		};
+		expect(getWorkflowStates(config)).toEqual([
+			"draft",
+			"review.market.pending",
+			"review.credit.pending",
+		]);
+	});
+});

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -20,3 +20,36 @@ export const getNextEvents = (
 
 	return nextEvents;
 };
+
+/**
+ * Extracts all non-final leaf state paths from an XState machine configuration.
+ * Paths are dot-delimited for nested states (e.g., "review.market.pending").
+ *
+ * @param machineConfig - The XState machine configuration
+ * @returns An array of state paths requiring forms
+ */
+export const getWorkflowStates = (
+	machineConfig: Record<string, any>,
+): string[] => {
+	const states: string[] = [];
+	const queue: { node: any; path: string[] }[] = [
+		{ node: machineConfig, path: [] },
+	];
+
+	while (queue.length) {
+		const { node, path } = queue.shift()!;
+
+		if (!node?.states) {
+			if (node?.type !== "final" && path.length) {
+				states.push(path.join("."));
+			}
+			continue;
+		}
+
+		for (const [key, value] of Object.entries(node.states)) {
+			queue.push({ node: value, path: [...path, key] });
+		}
+	}
+
+	return states;
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkflowInstancesIndexRouteImport } from './routes/workflowInstances/index'
 import { Route as WorkflowInstancesInstanceIdRouteImport } from './routes/workflowInstances/$instanceId'
+import { Route as AdminWorkflowNewRouteImport } from './routes/admin/workflow/new'
 import { Route as AdminWorkflowWorkflowIdFormsIndexRouteImport } from './routes/admin/workflow/$workflowId/forms/index'
 
 const IndexRoute = IndexRouteImport.update({
@@ -30,6 +31,11 @@ const WorkflowInstancesInstanceIdRoute =
     path: '/workflowInstances/$instanceId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const AdminWorkflowNewRoute = AdminWorkflowNewRouteImport.update({
+  id: '/admin/workflow/new',
+  path: '/admin/workflow/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AdminWorkflowWorkflowIdFormsIndexRoute =
   AdminWorkflowWorkflowIdFormsIndexRouteImport.update({
     id: '/admin/workflow/$workflowId/forms/',
@@ -41,12 +47,14 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/workflowInstances/$instanceId': typeof WorkflowInstancesInstanceIdRoute
   '/workflowInstances': typeof WorkflowInstancesIndexRoute
+  '/admin/workflow/new': typeof AdminWorkflowNewRoute
   '/admin/workflow/$workflowId/forms': typeof AdminWorkflowWorkflowIdFormsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/workflowInstances/$instanceId': typeof WorkflowInstancesInstanceIdRoute
   '/workflowInstances': typeof WorkflowInstancesIndexRoute
+  '/admin/workflow/new': typeof AdminWorkflowNewRoute
   '/admin/workflow/$workflowId/forms': typeof AdminWorkflowWorkflowIdFormsIndexRoute
 }
 export interface FileRoutesById {
@@ -54,6 +62,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/workflowInstances/$instanceId': typeof WorkflowInstancesInstanceIdRoute
   '/workflowInstances/': typeof WorkflowInstancesIndexRoute
+  '/admin/workflow/new': typeof AdminWorkflowNewRoute
   '/admin/workflow/$workflowId/forms/': typeof AdminWorkflowWorkflowIdFormsIndexRoute
 }
 export interface FileRouteTypes {
@@ -62,18 +71,21 @@ export interface FileRouteTypes {
     | '/'
     | '/workflowInstances/$instanceId'
     | '/workflowInstances'
+    | '/admin/workflow/new'
     | '/admin/workflow/$workflowId/forms'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/workflowInstances/$instanceId'
     | '/workflowInstances'
+    | '/admin/workflow/new'
     | '/admin/workflow/$workflowId/forms'
   id:
     | '__root__'
     | '/'
     | '/workflowInstances/$instanceId'
     | '/workflowInstances/'
+    | '/admin/workflow/new'
     | '/admin/workflow/$workflowId/forms/'
   fileRoutesById: FileRoutesById
 }
@@ -81,6 +93,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   WorkflowInstancesInstanceIdRoute: typeof WorkflowInstancesInstanceIdRoute
   WorkflowInstancesIndexRoute: typeof WorkflowInstancesIndexRoute
+  AdminWorkflowNewRoute: typeof AdminWorkflowNewRoute
   AdminWorkflowWorkflowIdFormsIndexRoute: typeof AdminWorkflowWorkflowIdFormsIndexRoute
 }
 
@@ -107,6 +120,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkflowInstancesInstanceIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/workflow/new': {
+      id: '/admin/workflow/new'
+      path: '/admin/workflow/new'
+      fullPath: '/admin/workflow/new'
+      preLoaderRoute: typeof AdminWorkflowNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/admin/workflow/$workflowId/forms/': {
       id: '/admin/workflow/$workflowId/forms/'
       path: '/admin/workflow/$workflowId/forms'
@@ -121,6 +141,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   WorkflowInstancesInstanceIdRoute: WorkflowInstancesInstanceIdRoute,
   WorkflowInstancesIndexRoute: WorkflowInstancesIndexRoute,
+  AdminWorkflowNewRoute: AdminWorkflowNewRoute,
   AdminWorkflowWorkflowIdFormsIndexRoute:
     AdminWorkflowWorkflowIdFormsIndexRoute,
 }

--- a/src/routes/admin/workflow/new.tsx
+++ b/src/routes/admin/workflow/new.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { API } from "@/data/API";
+import { getWorkflowStates } from "@/lib/workflow";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+
+export const Route = createFileRoute("/admin/workflow/new")({
+	component: WorkflowNewRoute,
+});
+
+function WorkflowNewRoute() {
+	const [name, setName] = useState("");
+	const [machineConfigText, setMachineConfigText] = useState("");
+	const [stateList, setStateList] = useState<string[]>([]);
+	const [forms, setForms] = useState<
+		Record<string, { formDefId?: string; schema?: string }>
+	>({});
+
+	const createWorkflow = useMutation({
+		mutationFn: (data: any) =>
+			API.workflowDefinition.mutations.createWorkflowDefinitionServerFn({
+				data,
+			}),
+		onSuccess: () => toast.success("Workflow created"),
+		onError: () => toast.error("Failed to create workflow"),
+	});
+
+	const parseStates = () => {
+		try {
+			const config = JSON.parse(machineConfigText);
+			const states = getWorkflowStates(config);
+			const init: Record<string, { formDefId?: string; schema?: string }> = {};
+			for (const state of states) {
+				init[state] = forms[state] || {};
+			}
+			setStateList(states);
+			setForms(init);
+		} catch {
+			toast.error("Invalid machine config");
+		}
+	};
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		try {
+			const machineConfig = JSON.parse(machineConfigText);
+			const formPayload: Record<string, any> = {};
+			for (const state of stateList) {
+				const info = forms[state];
+				if (info.formDefId) {
+					formPayload[state] = { formDefId: Number(info.formDefId) };
+				} else if (info.schema) {
+					formPayload[state] = { schema: JSON.parse(info.schema) };
+				}
+			}
+			createWorkflow.mutate({ name, machineConfig, forms: formPayload });
+		} catch {
+			toast.error("Invalid input");
+		}
+	};
+
+	return (
+		<div className="space-y-6">
+			<h2 className="text-xl font-semibold">New Workflow Definition</h2>
+			<form onSubmit={handleSubmit} className="space-y-4">
+				<div>
+					<label className="mb-1 block">Name</label>
+					<Input value={name} onChange={(e) => setName(e.target.value)} />
+				</div>
+				<div>
+					<label className="mb-1 block">Machine Config (JSON)</label>
+					<Textarea
+						rows={10}
+						value={machineConfigText}
+						onChange={(e) => setMachineConfigText(e.target.value)}
+					/>
+					<Button type="button" className="mt-2" onClick={parseStates}>
+						Load States
+					</Button>
+				</div>
+				{stateList.map((state) => (
+					<div key={state} className="rounded border p-4">
+						<h3 className="mb-2 font-medium">{state}</h3>
+						<div className="space-y-2">
+							<div>
+								<label className="mb-1 block">
+									Existing Form Definition ID
+								</label>
+								<Input
+									value={forms[state]?.formDefId || ""}
+									onChange={(e) =>
+										setForms({
+											...forms,
+											[state]: { ...forms[state], formDefId: e.target.value },
+										})
+									}
+								/>
+							</div>
+							<div>
+								<label className="mb-1 block">New Form Schema (JSON)</label>
+								<Textarea
+									rows={6}
+									value={forms[state]?.schema || ""}
+									onChange={(e) =>
+										setForms({
+											...forms,
+											[state]: { ...forms[state], schema: e.target.value },
+										})
+									}
+								/>
+							</div>
+						</div>
+					</div>
+				))}
+				<Button type="submit" disabled={createWorkflow.isPending}>
+					Create Workflow
+				</Button>
+			</form>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- support configuring new XState workflows, automatically associating form definitions with each non-terminal state
- expose server mutation and dashboard link for creating new workflows, plus helper to extract workflow states
- add route for workflow configuration and tests for state extraction including parallel states
- replace recursive workflow state extraction with iterative traversal

## Testing
- `pnpm format`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b2e3a2dac8832ea06e8754a5f2724f